### PR TITLE
Please support DESTDIR

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,22 +6,22 @@ LUA_SHAREDIR=$(LUA_PREFIX)/share/lua/5.1
 ldoc:
 
 install: install_parts
-	echo "lua $(LUA_SHAREDIR)/ldoc.lua \$$*" > $(LUA_BINDIR)/ldoc
-	chmod +x $(LUA_BINDIR)/ldoc
+	echo "lua $(LUA_SHAREDIR)/ldoc.lua \$$*" > $(DESTDIR)$(LUA_BINDIR)/ldoc
+	chmod +x $(DESTDIR)$(LUA_BINDIR)/ldoc
 
 install_luajit: install_parts
-	echo "luajit $(LUA_SHAREDIR)/ldoc.lua \$$*" > $(LUA_BINDIR)/ldoc
-	chmod +x $(LUA_BINDIR)/ldoc
+	echo "luajit $(LUA_SHAREDIR)/ldoc.lua \$$*" > $(DESTDIR)$(LUA_BINDIR)/ldoc
+	chmod +x $(DESTDIR)$(LUA_BINDIR)/ldoc
 
 install_parts:
-	mkdir -p $(LUA_SHAREDIR)
-	cp ldoc.lua $(LUA_SHAREDIR)
-	cp -r ldoc $(LUA_SHAREDIR)
+	mkdir -p $(DESTDIR)$(LUA_SHAREDIR)
+	cp ldoc.lua $(DESTDIR)$(LUA_SHAREDIR)
+	cp -r ldoc $(DESTDIR)$(LUA_SHAREDIR)
 
 uninstall:
-	-rm $(LUA_SHAREDIR)/ldoc.lua
-	-rm -r $(LUA_SHAREDIR)/ldoc
-	-rm $(LUA_BINDIR)/ldoc
+	-rm $(DESTDIR)$(LUA_SHAREDIR)/ldoc.lua
+	-rm -r $(DESTDIR)$(LUA_SHAREDIR)/ldoc
+	-rm $(DESTDIR)$(LUA_BINDIR)/ldoc
 
 test: test-basic test-example test-md test-tables
 


### PR DESCRIPTION
The install\* targets should support DESTDIR. I will attach a trivial patch.
