### PR TITLE
Custom tags

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -193,7 +193,7 @@ function ldoc.custom_see_handler(pat, handler)
 end
 
 local ldoc_contents = {
-   'alias','add_language_extension','new_type','add_section', 'tparam_alias',
+   'alias','add_language_extension','custom_tags','new_type','add_section', 'tparam_alias',
    'file','project','title','package','format','output','dir','ext', 'topics',
    'one','style','template','description','examples', 'pretty', 'charset', 'plain',
    'readme','all','manual_url', 'ignore', 'colon', 'sort', 'module_file','vars',
@@ -306,6 +306,16 @@ else
    -- with user-provided file
    args.file = abspath(args.file)
 end
+
+if type(ldoc.custom_tags) == 'table' then -- custom tags
+  for i, custom in ipairs(ldoc.custom_tags) do
+    if type(custom) == 'string' then
+      custom = {custom}
+      ldoc.custom_tags[i] = custom
+    end
+    doc.add_tag(custom[1], 'ML')
+  end
+end -- custom tags
 
 local source_dir = args.file
 if type(source_dir) == 'table' then

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -148,6 +148,21 @@ return [==[
     </dt>
     <dd>
     $(M(ldoc.descript(item),item))
+    
+#   if ldoc.custom_tags then
+#    for custom in iter(ldoc.custom_tags) do
+#     local tag = item.tags[custom[1]]
+#     if tag then
+#      local li,il = use_li(tag)
+    <h3>$(custom.title or custom[1]):</h3>
+    <ul>
+#      for value in iter(tag) do
+         $(li)$(custom.format and custom.format(value) or M(value))$(il)
+#      end -- for
+#     end -- if tag
+    </ul>
+#    end -- iter tags
+#   end
 
 #  if show_parms and item.params and #item.params > 0 then
 #    local subnames = module.kinds:type_of(item).subnames


### PR DESCRIPTION
Custom tags. Add them to config.ld like this:

```
custom_tags = {
  { 'path', title = 'Resource path',
    format = function(v) return '<pre>' .. v .. '</pre>' end } ,
} 
```

This is a quick way to get ldoc to recognize arbitrary tags and document them just after the item description. All tags are registered as multiline for now, but this could be improved later.

`custom_tags` is a numeric table containing tables with keys:
- `1`: The tag name
- `title` (optional): A label for the h3, like "Parameters"
- `format` (optional): A function to format the tag's value 

If you don't need title or format you can use string values instead of tables:

```
custom_tags = {  'sometag', 'anothertag', } 
```
