### PR TITLE
Unify the way optional params are displayed.

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -61,6 +61,7 @@ ldoc, a documentation generator for Lua, vs 1.4.0
   -M,--merge allow module merging
   -S,--simple no return or params, no summary
   -O,--one one-column output layout
+  -P,--plain_params    don't show brackets or default values in param lists
   --dump                debug output dump
   --filter (default none) filter output as Lua data (e.g pl.pretty.dump)
   --tags (default none) show all references to given tags, comma-separated
@@ -200,7 +201,7 @@ local ldoc_contents = {
    'boilerplate','merge', 'wrap', 'not_luadoc', 'template_escape','merge_error_groups',
    'no_return_or_parms','no_summary','full_description','backtick_references', 'custom_see_handler',
    'no_space_before_args','parse_extra','no_lua_ref','sort_modules','use_markdown_titles',
-   'unqualified',
+   'plain_params', 'unqualified',
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 
@@ -316,6 +317,9 @@ if type(ldoc.custom_tags) == 'table' then -- custom tags
     doc.add_tag(custom[1], 'ML')
   end
 end -- custom tags
+
+override 'plain_params'
+ldoc.plain_params = args.plain_params
 
 local source_dir = args.file
 if type(source_dir) == 'table' then

--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -181,8 +181,10 @@ function html.generate_output(ldoc, args, project)
       return type(t) == 'table' and t.append
    end
 
-   function ldoc.typename (tp)
-      if not tp or tp == '' or tp:match '^@' then return '' end
+   function ldoc.typename (tp, pmods)
+      if not tp or tp == '' or tp:match '^@' then
+         return pmods and pmods.opt and 'optional' or ''
+      end
       local optional
       -- ?<type> is short for ?nil|<type>
       if tp:match("^%?") and not tp:match '|' then
@@ -194,6 +196,9 @@ function html.generate_output(ldoc, args, project)
          tp = tp2
       end
 
+      if pmods and pmods.opt then
+         optional = true
+      end
       local types = {}
       for name in tp:gmatch("[^|]+") do
          local sym = name:match '([%w%.%:]+)'

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -177,7 +177,9 @@ return [==[
         <ul>
 #     end
 #     for p in iter(param) do
-#        local name,tp,def = item:display_name_of(p), ldoc.typename(item:type_of_param(p)), item:default_of_param(p)
+#        local name = item:display_name_of(p)
+#        local tp = ldoc.typename(item:type_of_param(p), item:param_modifiers(p))
+#        local def = item:default_of_param(p)
         <li><span class="parameter">$(name)</span>
 #       if tp ~= '' then
             <span class="types">$(tp)</span>


### PR DESCRIPTION
LDoc has two different ways to annotate optional parameters, [opt] and [type=?foo]. This patch attempts to resolve the differences in the way optional parameters display: [opt] params are shown as "optional" in the param description, and [type=?] params are shown in brackets in the param list. Also added a --plain_params setting to turn off brackets and default values in the param list. 
- Params with modifiers like [type=?foo] have brackets in param list.
- Params with modifiers like [opt] show up as "optional" in param description.
- Add -P,--plain_params setting for no brackets or defaults in param list.
