### PR TITLE
Custom display_name handler.

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1110,6 +1110,20 @@ when using Markdown. When explicit will expand non-references in backticks into 
 'file:///D:/dev/lua/projects/lua-5.1.4/doc/manual.html'
   - `no_summary` suppress the Contents summary
   - `custom_see_handler` function that filters see-references
+  - `custom_display_name_handler` function that formats an item's name. The arguments are the item
+and the default function used to format the name. For example, to show an icon or label beside any
+function tagged with a certain tag:
+      -- define a @callback tag:
+      custom_tags = { { 'callback', hidden = true } }
+
+      -- show a label beside functions tagged with @callback.
+      custom_display_name_handler = function(item, default_handler)
+        if item.type == 'function' and item.tags.callback then
+          return item.name .. ' [callback]'
+        end
+        return default_handler(item)
+      end
+      
   - `not_luadoc` set to `true` if the docs break LuaDoc compatibility
   - `no_space_before_args` set to `true` if you do not want a space between a function's name and its arguments.
   - `template_escape` overrides the usual '#' used for Lua code in templates. This needs to be changed if the output format is Markdown, for instance.

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -200,7 +200,7 @@ local ldoc_contents = {
    'boilerplate','merge', 'wrap', 'not_luadoc', 'template_escape','merge_error_groups',
    'no_return_or_parms','no_summary','full_description','backtick_references', 'custom_see_handler',
    'no_space_before_args','parse_extra','no_lua_ref','sort_modules','use_markdown_titles',
-   'unqualified',
+   'unqualified', 'custom_display_name_handler',
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 

--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -156,7 +156,7 @@ function html.generate_output(ldoc, args, project)
       if #ls > 1 then return '<li>','</li>' else return '','' end
    end
 
-   function ldoc.display_name(item)
+   function ldoc.default_display_name(item)
       local name = item.display_name or item.name
       if item.type == 'function' or item.type == 'lfunction' then
          if not ldoc.no_space_before_args then
@@ -165,6 +165,14 @@ function html.generate_output(ldoc, args, project)
          return name..item.args
       else
          return name
+      end
+   end
+
+   function ldoc.display_name(item)
+      if ldoc.custom_display_name_handler then
+        return ldoc.custom_display_name_handler(item, ldoc.default_display_name)
+      else
+        return ldoc.default_display_name(item)
       end
    end
 


### PR DESCRIPTION
Currently, if we want to tweak how a function name is displayed we have to use our own template. It's unfortunate.

The following patch makes it possible to define a display_name handler in our `config.ld`.

The documentation contains an example that shows how to print an icon/label beside a function marked with a certain tag. (That example uses the `hidden` feature from #121 but it's not mandatory; I could remove it.)
