### PR TITLE
Putting "Repeating tags" one level up, since not related to Lua 5.1 modules

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -223,7 +223,7 @@ However, the 'module' function is deprecated in Lua 5.2 and it is increasingly
 common to see less 'magic' ways of creating modules, as seen in the description
 of the 'module' tag previously with the explicitely returned module table.
 
-#### Repeating tags
+### Repeating tags
 
 Tags like 'param' and 'return' can be specified multiple times, whereas a type
 tag like 'function' can only occur once in a comment.


### PR DESCRIPTION
With my last docs text sorting suggestions I accidentally made "Repeating tags" a subsection of "Doing modules the Lua 5.1 way", while it should be on the same level. (or a subsection of something else, but definitely not that)