### PR TITLE
Simularly -> Similarly in doc.md

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -661,7 +661,7 @@ you can write:
         B = 2; -- beta
     }
 
-Simularly, function parameter comments can be directly used:
+Similarly, function parameter comments can be directly used:
 
     ------------
     -- third function. Can also provide parameter comments inline,


### PR DESCRIPTION
This is an old typo and mentioned in #3 and #71. Since it has drifted again, I updated the patch.
