### PR TITLE
Fix undefined quote in Item:build_return_groups

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -913,6 +913,7 @@ end
 local struct_return_type = '*'
 
 function Item:build_return_groups()
+   local quote = tools.quote
    local modifiers = self.modifiers
    local retmod = modifiers['return']
    local groups = List()


### PR DESCRIPTION
got following error:

```
/Users/mikz/Developer/3scale/slug/monitor/lua/http_ng/response.lua:48: internal LDoc error
/usr/local/share/lua/5.2/ldoc/doc.lua:931: attempt to call global 'quote' (a nil value)
stack traceback:
    /usr/local/share/lua/5.2/ldoc/doc.lua:931: in function 'build_return_groups'
    /usr/local/share/lua/5.2/ldoc/doc.lua:758: in function 'finish'
    /usr/local/share/lua/5.2/ldoc/doc.lua:236: in function 'finish'
    /usr/local/share/lua/5.2/ldoc/parse.lua:404: in function </usr/local/share/lua/5.2/ldoc/parse.lua:404>
```
