### PR TITLE
Make custom_display_name work for project-level items

### DIFF
--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -176,6 +176,11 @@ function ldoc.source_ref (fun)
    end
 
    function ldoc.default_display_name(item)
+      -- Project-level items:
+      if doc.project_level(item.type) then
+        return ldoc.module_name(item)
+      end
+      -- Module-level items:
       local name = item.display_name or item.name
       if item.type == 'function' or item.type == 'lfunction' then
          if not ldoc.no_space_before_args then

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -66,7 +66,7 @@ return [==[
 #  if ldoc.allowed_in_contents(type,module) then
 <h2>$(kind)</h2>
 <ul class="$(kind=='Topics' and '' or 'nowrap'">
-#  for mod in mods() do local name = ldoc.module_name(mod)
+#  for mod in mods() do local name = display_name(mod)
 #   if mod.name == this_mod then
   <li><strong>$(name)</strong></li>
 #   else


### PR DESCRIPTION
Sometimes I wish to customize the way items on the sidebar are shown. This includes names of modules, topics, etc.

But these items ("project-level" items) don't currently pass through custom_display_name.

This patch fixes this.

What is this good for?

For gazillion of things!

(1) For example, some of my modules aren't "real" module. E.g., I document all my global functions under a pseudo module called "globals". I want to show such modules' names inside parentheses. To do this, I can now add "@pseudo" to all my such module and do the following in my config.ld:

``` lua
    custom_tags = {
      { 'pseudo', hidden = true },
    }

    custom_display_name_handler = function(item, default_handler)

      if item.type == 'module' then
        if item.tags.pseudo then
          return '(' .. default_handler(item) .. ')'
        end
      end

      return default_handler(item)
    end
```

(2) "Topic" files (MarkDown files) currently have their file names shown as their presentational names. That's awkward sometimes. I want to show their first non-empty line instead. Here's a solution:

``` lua
    custom_display_name_handler = function(item, default_handler)

      if item.type == 'topic' then
        if item.body then
          local title = item.body:match('(%w[^\n]+)')
          if title then
            return title    -- @todo: We need to html-escape this.
          end
        end
      end

      return default_handler(item)
    end
```
