### PR TITLE
Have CSS classes for section header and description

### DIFF
--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -93,7 +93,7 @@ function html.generate_output(ldoc, args, project)
 
    -- Item descriptions come from combining the summary and description fields
    function ldoc.descript(item)
-      return (item.summary or '?')..' '..(item.description or '')
+      return tools.join(' ', item.summary, item.description)
    end
 
    function ldoc.module_name (mod)

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -134,10 +134,15 @@ return [==[
 # local show_parms = show_return
 # for kind, items in module.kinds() do
 #   local kitem = module.kinds:get_item(kind)
-    <h2><a name="$(no_spaces(kind))"></a>$(kind)</h2>
+#   local has_description = kitem and ldoc.descript(kitem) ~= ""
+    <h2 class="section-header $(has_description and 'has-description')"><a name="$(no_spaces(kind))"></a>$(kind)</h2>
     $(M(module.kinds:get_section_description(kind),nil))
 #   if kitem then
-        $(M(ldoc.descript(kitem),kitem))
+#       if has_description then
+          <div class="section-description">
+          $(M(ldoc.descript(kitem),kitem))
+          </div>
+#       end
 #       if kitem.usage then
             <h3>Usage:</h3>
             <pre class="example">$(ldoc.prettify(kitem.usage[1]))</pre>

--- a/ldoc/tools.lua
+++ b/ldoc/tools.lua
@@ -202,6 +202,27 @@ function M.strip (s)
    return s:gsub('^%s+',''):gsub('%s+$','')
 end
 
+-- Joins strings using a separator.
+--
+-- Empty strings and nil arguments are ignored:
+--
+--    assert(join('+', 'one', '', 'two', nil, 'three') == 'one+two+three')
+--    assert(join(' ', '', '') == '')
+--
+-- This is especially useful for the last case demonstrated above,
+-- where "conventional" solutions (".." or table.concat) would result
+-- in a spurious space.
+function M.join(sep, ...)
+  local contents = {}
+  for i = 1, select('#', ...) do
+    local value = select(i, ...)
+    if value and value ~= "" then
+      contents[#contents + 1] = value
+    end
+  end
+  return table.concat(contents, sep)
+end
+
 function M.check_directory(d)
    if not path.isdir(d) then
       lfs.mkdir(d)


### PR DESCRIPTION
This simple patch makes it possible to style sections.

To understand why it's important, here's a "before" page that shows the current sad situation:

http://www.typo.co.il/~mooffie/tmp/before.html

This page looks like a long jumble of text. The user isn't likely to read the section descriptions because they aren't distinguishable from function items. It's a mess.

Now,

Here's an "after" page, whose CSS takes advantage of the ability to style section headers/descriptions:

http://www.typo.co.il/~mooffie/tmp/after.html

I think it's a major usability improvement.

(The CSS I used here is [this one](http://www.typo.co.il/~mooffie/tmp/mycss.txt). After I finish with this project I'll make my configuration files public.)

**Note**: The reason we output the `<div class="section-description">` only, and only if, there's actually a description is because a style like `.section-description {border: 1px solid green}` affects empty DIVs too and we want to void this.
