### PR TITLE
Have postprocess_html

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1278,6 +1278,9 @@ This needs to be changed if the output format is Markdown, for instance.
   - `user_keywords` A list of keywords that will be marked in "prettified" code. Useful if
 you want to display your own functions in a special way. Each keyword may be styled differently
 (using CSS). Only works when `pretty` is set to 'lua' (the default).
+  - `postprocess_html` function that allows a last-minute modification to the produced HTML page.
+The arguments are the raw HTML that's intended to be written out (a string), and the module object.
+The string this function returns will be what's actually gets written out.
 
 _Available functions are:_
 

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -234,6 +234,7 @@ local ldoc_contents = {
    'no_space_before_args','parse_extra','no_lua_ref','sort_modules','use_markdown_titles',
    'unqualified', 'custom_display_name_handler', 'kind_names', 'custom_references',
    'dont_escape_underscore','global_lookup','prettify_files','convert_opt', 'user_keywords',
+   'postprocess_html',
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 


### PR DESCRIPTION
This simple patch introduces a hook that lets one perform last-minute modification of the HTML.

(Purists may not like having people manipulate a HTML string, preferring them to manipulate some data structure instead, and they're right, but ldoc doesn't readily have the required infrastructure for this, and this somewhat inelegant solution, in this patch, of modifying HTML, is better than nothing.)

So, what can one do with this hook?
- One can add a link to a CSS or JS file to the `<head>`er.
- One can convert simple tokens and "macros" to nice markup. For example, here's how to make any paragraph that starts with "Note:" stand out:

``` lua
    function postprocess_html(s)
      s = s:gsub("<p>%s*Note:(.-)</p>", '<div class="message note"><p>%1</p></div>')
      return s
    end
```

You can see the result of a similar manipulation here:

http://typo.co.il/~mooffie/tmp/ldoc/postprocess_html/tty.html

Here I used postprocess_html to support 3 types of paragraphs: notes, ideas, infos, each having a different icon in their boxes.

(The hook is named postprocess_html, not html_postprocess, because in the future we may have postprocess_item etc. and putting the "postprocess" first could make the documentation more organized.)
