### PR TITLE
Show exact error when template loading fails

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -753,7 +753,7 @@ if builtin_style or builtin_template then
    local function tmpwrite (name)
       local ok,text = pcall(require,'ldoc.html.'..name:gsub('%.','_'))
       if not ok then
-         quit("cannot find builtin template "..name)
+         quit("cannot find builtin template "..name.." ("..text..")")
       end
       if not utils.writefile(path.join(tmpdir,name),text) then
          quit("cannot write to temp directory "..tmpdir)


### PR DESCRIPTION
This is a tiny patch that makes error messages --in case there's some Lua error somewhere in ldoc/html/*.lua-- more verbose.

for example, if you ship a new version but forget to ship the two new files (ldoc/html/{_code_css,_reset_css}.lua) in the tarball, the user will see a meaningful error instead of an enigmatic one.)
