### PR TITLE
Fix @{error} links

### DIFF
--- a/ldoc/builtin/globals.lua
+++ b/ldoc/builtin/globals.lua
@@ -9,6 +9,7 @@ globals.functions = {
    assert = true,
    collectgarbage = true,
    dofile = true,
+   error = true,
    getmetatable = true,
    setmetatable = true,
    pairs = true,


### PR DESCRIPTION
For some reason "error" was missing from the global functions list.