### PR TITLE
Using ldoc.prettify_files the same way as for example ldoc.examples

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -557,6 +557,8 @@ if type(ldoc.examples) == 'table' then
    prettify_source_files(ldoc.examples,"example")
 end
 
+ldoc.is_file_prettyfied = {}
+
 if ldoc.prettify_files then
    local files = List()
    local linemap = {}
@@ -569,6 +571,17 @@ if ldoc.prettify_files then
       end
       linemap[F.filename] = ls
    end
+
+   if type(ldoc.prettify_files) == 'table' then
+      files = tools.expand_file_list(ldoc.prettify_files, '*.*')
+   -- -- not sure about resolving ldoc.prettify_files as string due to backward compatibility, see:
+   -- --     - tests/styles/opt.ld:7
+   -- --     - doc/html.lua:266
+   -- elseif type(ldoc.prettify_files) == 'string' then
+   --    files = tools.expand_file_list({ldoc.prettify_files}, '*.*')
+   end
+
+   ldoc.is_file_prettyfied = tablex.makeset(files)
    prettify_source_files(files,"file",linemap)
 end
 

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -153,7 +153,7 @@ return [==[
     <dt>
     <a name = "$(item.name)"></a>
     <strong>$(display_name(item))</strong>
-#   if ldoc.prettify_files then
+#   if ldoc.prettify_files and ldoc.is_file_prettyfied[item.module.file.filename] then
     <a style="float:right;" href="$(ldoc.source_ref(item))">line $(item.lineno)</a>
 #  end
     </dt>


### PR DESCRIPTION
I wanted to make links to source codes of files/functions/classes/... available but with exception for two special files so now I can treat with *prettify_files* pretty the same way as with *examples* in config.ld.

Just was not sure if setting prettify_files given as string (for example *prettify_files = 'src'*) should be also expanded due to backward compatibility (see files below) so the piece of code to do that is for now commented out.

 * [tests/styles/opt.ld:7](https://github.com/stevedonovan/LDoc/blob/master/tests/styles/opt.ld#L7)
 * [doc/html.lua:266](https://github.com/stevedonovan/LDoc/blob/master/ldoc/html.lua#L266)