### PR TITLE
Allow brief project description to be specified on command line

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -1215,6 +1215,7 @@ _Same meaning as the corresponding parameters:_
 of files and directories.
   - `project` name of project, used as title in top left
   - `title` page title, default 'Reference'
+  - `description` a short project description used under the project title
   - `package ` explicit base package name; also used for resolving references in documents
   - `all` show local functions, etc as well in the docs
   - `format` markup processor, can be 'plain' (default), 'markdown' or 'discount'
@@ -1232,7 +1233,6 @@ explicit **@submodule** tag
 
 _These only appear in the configuration file:_
 
-  - `description` a short project description used under the project title
   - `full_description` when you _really_ need a longer project description
   - `examples` a directory or file: can be a table
   - `readme` or `topics` readme files (to be processed with Markdown)

--- a/ldoc.lua
+++ b/ldoc.lua
@@ -61,6 +61,7 @@ ldoc, a documentation generator for Lua, vs 1.4.3
   -M,--merge allow module merging
   -S,--simple no return or params, no summary
   -O,--one one-column output layout
+  --description (default none) project description
   --dump                debug output dump
   --filter (default none) filter output as Lua data (e.g pl.pretty.dump)
   --tags (default none) show all references to given tags, comma-separated
@@ -780,6 +781,7 @@ ldoc.log = print
 ldoc.kinds = project
 ldoc.modules = module_list
 ldoc.title = ldoc.title or args.title
+ldoc.description = ldoc.description or utils.choose(args.description ~= "none", args.description);
 ldoc.project = ldoc.project or args.project
 ldoc.package = args.package:match '%a+' and args.package or nil
 ldoc.updatetime = os.date("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This should allow a brief project description to be passed through the command line. This was useful for my team to include specific changelist information through our build system.