### PR TITLE
Adding module-level see reference support.

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -1198,7 +1198,8 @@ end
 -- and try to to resolve this.
 function Module:resolve_references(modules)
    local found = List()
-   for item in self.items:iter() do
+   -- Resolve see references in item. Can be Module or Item type.
+   local function resolve_item_references(item)
       local see = item.tags.see
       if see then -- this guy has @see references
          item.see = List()
@@ -1212,6 +1213,11 @@ function Module:resolve_references(modules)
             end
          end
       end
+   end
+
+   resolve_item_references(self); -- Resolve module-level see references.
+   for item in self.items:iter() do
+      resolve_item_references(item); -- Resolve item-level see references.
    end
    -- mark as found, so we don't waste time re-searching
    for f in found:iter() do

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -90,6 +90,15 @@ return [==[
 #   if module.tags.include then
         $(M(ldoc.include_file(module.tags.include)))
 #   end
+#   if module.see then
+#     local li,il = use_li(module.see)
+    <h3>See also:</h3>
+    <ul>
+#     for see in iter(module.see) do
+         $(li)<a href="$(ldoc.href(see))">$(see.label)</a>$(il)
+#    end -- for
+    </ul>
+#   end -- if see
 #   if module.usage then
 #     local li,il = use_li(module.usage)
     <h3>Usage:</h3>


### PR DESCRIPTION
Since LDoc treats modules internally as a special case of items, it was easy to extend the @see tag to work within the module header documentation.