### PR TITLE
Allow "]" in description after tag modifiers

### DIFF
--- a/ldoc/parse.lua
+++ b/ldoc/parse.lua
@@ -22,7 +22,7 @@ local tnext, append = lexer.skipws, table.insert
 -- followed by the value, which may extend over several lines.
 local luadoc_tag = '^%s*@(%w+)'
 local luadoc_tag_value = luadoc_tag..'(.*)'
-local luadoc_tag_mod_and_value = luadoc_tag..'%[(.*)%](.*)'
+local luadoc_tag_mod_and_value = luadoc_tag..'%[([^%]]*)%](.*)'
 
 -- assumes that the doc comment consists of distinct tag lines
 local function parse_at_tags(text)


### PR DESCRIPTION
In situations like this:

    ---
    -- Test to demonstrate that "]" after a tag modifier breaks LDoc.
    -- @module test

    ---
    -- @function test
    -- @string[opt]  arg  Must not contain any ] brackets
    return function(arg)
    end

LDoc outputs something like this:

### Parameters: ###

* `brackets:` ([string](#))

Expected would be:

### Parameters: ###

* `arg:` ([string](#)) Must not contain any ] brackets (*optional*)
