### PR TITLE
Avoid return documentation slipping into preceding function documenation

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -141,7 +141,7 @@ function doc.expand_annotation_item (tags, last_item)
          tags:add('name',item_name..'-'..tag..acount)
          acount = acount + 1
          return true
-      elseif tag == 'return' then
+      elseif tags.error and tag == 'return' then
          last_item:set_tag(tag,value)
       end
    end


### PR DESCRIPTION
Please review - I'm not 100% certain about the consequences this has.  It seems to me the tests in the test folder aren't intended for automated regression tests, are they?

In a module like this:

    ---
    -- some module
    -- @module some_module


    ---
    --
    -- @function currentDocumentPath
    -- @treturn string
    --   Full document path, including file name and extension
    local function currentDocumentPath()
        -- some code
        return path
    end


    --- 
    -- 
    -- @function currentDocumentFolder
    -- @treturn string
    --   The folder the document is stored in
    local function currentDocumentFolder()
      -- some code
      return path
    end


    return {
        currentDocumentPath = currentDocumentPath,
        currentDocumentFolder = currentDocumentFolder
    }


the output will look like this:

<dl class="function">
    <dt>
    <a name="currentDocumentPath"></a>
    <strong>currentDocumentPath ()</strong>
    </dt>
    <dd>




    <h3>Returns:</h3>
    <ol>
        <li>
           <span class="types"><a class="type" href="http://www.lua.org/manual/5.2/manual.html#6.4">string</a></span>
        Full document path, including file name and extension</li>
        <li>
           <span class="types"><a class="type" href="http://www.lua.org/manual/5.2/manual.html#6.4">string</a></span>
        The folder the document is stored in.</li>
    </ol>




</dd>
    <dt>
    <a name="currentDocumentFolder"></a>
    <strong>currentDocumentFolder ()</strong>
    </dt>
    <dd>




    <h3>Returns:</h3>
    <ol>

           <span class="types"><a class="type" href="http://www.lua.org/manual/5.2/manual.html#6.4">string</a></span>
        The folder the document is stored in
    </ol>




</dd>
</dl>


i.e. the return of the second function will falsely also be included in the first function.  This pull request fixes this.  The line that it modifies [obviously was introduced for supporting `@error` tags](https://github.com/stevedonovan/LDoc/commit/8395d6d9d7db624e0794d72aaa701cf23baa12eb#diff-0bd2114c3d0bafe421eed56780bb7485R141) in commit 0bd2114.  `@error` tags still seem to work with this pull request.