### PR TITLE
add custom_css configuration param

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -236,6 +236,7 @@ local ldoc_contents = {
    'unqualified', 'custom_display_name_handler', 'kind_names', 'custom_references',
    'dont_escape_underscore','global_lookup','prettify_files','convert_opt', 'user_keywords',
    'postprocess_html',
+   'custom_css',
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 

--- a/ldoc/html.lua
+++ b/ldoc/html.lua
@@ -296,7 +296,7 @@ function ldoc.source_ref (fun)
       return cleanup_whitespaces(out)
    end
 
-   local css = ldoc.css
+   local css, custom_css = ldoc.css, ldoc.custom_css
    ldoc.output = args.output
    ldoc.ipairs = ipairs
    ldoc.pairs = pairs
@@ -329,6 +329,10 @@ function ldoc.source_ref (fun)
       check_file(args.dir..css, path.join(args.style,css))
    end
 
+   if custom_css then -- has custom CSS been copied?
+      check_file(args.dir..custom_css, custom_css)
+   end
+
    -- write out the module index
    out = cleanup_whitespaces(out)
    writefile(args.dir..args.output..args.ext,out)
@@ -348,6 +352,9 @@ function ldoc.source_ref (fun)
    -- e.g. when reading a topic the other Topics will be listed first.
    if css then
       ldoc.css = '../'..css
+   end
+   if custom_css then
+      ldoc.custom_css = '../'..custom_css
    end
    for m in mods:iter() do
       local kind, lkind, modules = unpack(m)

--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -6,6 +6,9 @@ return [==[
 <head>
     <title>$(ldoc.title)</title>
     <link rel="stylesheet" href="$(ldoc.css)" type="text/css" />
+# if ldoc.custom_css then -- add custom CSS file if configured.
+    <link rel="stylesheet" href="$(ldoc.custom_css)" type="text/css" />
+# end
 </head>
 <body>
 


### PR DESCRIPTION
This is a proof of concept to add a ```custom_css``` configuration parameter -- the idea being that instead of a wholesale replacement of the default CSS, some simple CSS overrides via a custom file included after the base CSS will allow a large amount of CSS control while still benefiting from the work already done.

As an example, these overrides of the default CSS:
```css
html, body {
  height: 100%;
  width: 100%;
  padding: 0;
  margin: 0;
}
body {
  background: #fffae5;
}
#container {
  background: #fffae5;
}
#main {
  background: #fffae5;
}
#navigation {
  background: #fffae5;
}
#navigation h2 {
  margin-right: 10px;
  border: 1px solid gray;
  border-radius: 5px;
}
#content {
  background: #fffae5;
  height: 100%;
}
#about {
  display: none;
}
table.module_list td.name,
table.module_list td.summary,
table.function_list td.name,
table.function_list td.summary {
  background: #fffae5;
  border-color: gray;
}
a:link, a:visited {
  color: #800000;
}
```
Results in this page: http://thehunmonkgroup.github.io/luchia/doc/

There will still need to be a bit more work done for this to be commit-worthy, especially:
 * smarter path resolution for the setting, currently only the file name of the file placed in the same directory as the config.ld will work
 * command line support

If you like this addition, I'm happy to work with you to round out the patch.