### PR TITLE
Fix @within

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -23,9 +23,9 @@ local TAG_MULTI,TAG_ID,TAG_SINGLE,TAG_TYPE,TAG_FLAG,TAG_MULTI_LINE = 'M','id','S
 --  - 'T' tags which represent a type, like 'function' (TAG_TYPE)
 local known_tags = {
    param = 'M', see = 'M', comment = 'M', usage = 'ML', ['return'] = 'M', field = 'M', author='M',set='M';
-   class = 'id', name = 'id', pragma = 'id', alias = 'id', within = 'id',
+   class = 'id', name = 'id', pragma = 'id', alias = 'id',
    copyright = 'S', summary = 'S', description = 'S', release = 'S', license = 'S',
-   fixme = 'S', todo = 'S', warning = 'S', raise = 'S', charset = 'S',
+   fixme = 'S', todo = 'S', warning = 'S', raise = 'S', charset = 'S', within = 'S',
    ['local'] = 'N', export = 'N', private = 'N', constructor = 'N', static = 'N',include = 'S',
    -- project-level
    module = 'T', script = 'T', example = 'T', topic = 'T', submodule='T', classmod='T', file='T',
@@ -294,7 +294,7 @@ function File:finish()
             end
             item.display_name = display_name
             this_mod.section = item
-            this_mod.kinds:add_kind(display_name,display_name..' ',nil,item)
+            this_mod.kinds:add_kind(display_name,display_name,nil,item)
             this_mod.sections:append(item)
             this_mod.sections.by_name[lookup_name:gsub('%A','_')] = item
          end


### PR DESCRIPTION
A within tag is set to type 'id' while sections are set by the summary of their item, so that pretty much would never work unless you used one word summaries. Then, even if you did use a one word summary, LDoc is adding an extra space (introduced in #113, no idea the reasoning behind that) to the section name and not when within inits its section, so you'd end up with two sections (the referenced section and a new section without the space) with the function added to both for whatever reason as reported in #92.

So I changed the within tag type and removed the space and everything seems to be working fine. Making within work off the section tag name instead of the summary would probably be the best thing to do (how it worked at some point in the past?), but that looked a bit more involved.