### PR TITLE
Honour the SOURCE_DATE_EPOCH environment variable

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -803,10 +803,14 @@ ldoc.title = ldoc.title or args.title
 ldoc.project = ldoc.project or args.project
 ldoc.package = args.package:match '%a+' and args.package or nil
 
-if args.date == 'system' then
-   ldoc.updatetime = os.date("%Y-%m-%d %H:%M:%S")
+if os.getenv("SOURCE_DATE_EPOCH") == nil then
+  if args.date == 'system' then
+    ldoc.updatetime = os.date("%Y-%m-%d %H:%M:%S")
+  else
+    ldoc.updatetime = args.date
+  end
 else
-   ldoc.updatetime = args.date
+  ldoc.updatetime = os.date("!%Y-%m-%d %H:%M:%S",os.getenv("SOURCE_DATE_EPOCH"))
 end
 
 local html = require 'ldoc.html'


### PR DESCRIPTION
When the environment variable SOURCE_DATE_EPOCH is set, use it as the epoch of the date to be written in the output.
This allows to build reproducibly packages depending on LDoc to build their documentation, without any change to their code and build process.
See https://reproducible-builds.org/specs/source-date-epoch/