### PR TITLE
Change `git://` to `https://`

### DIFF
--- a/ldoc-scm-2.rockspec
+++ b/ldoc-scm-2.rockspec
@@ -3,7 +3,7 @@ version = "scm-2"
 
 source = {
   dir="LDoc",
-  url = "git://github.com/stevedonovan/LDoc.git"
+  url = "https://github.com/stevedonovan/LDoc.git"
 }
 
 description = {


### PR DESCRIPTION
`git://` is insecure.  `https://` should be used instead.