### PR TITLE
Fix module call parse

### DIFF
--- a/ldoc/parse.lua
+++ b/ldoc/parse.lua
@@ -246,7 +246,7 @@ local function parse_file(fname, lang, package, args)
          --return nil
       else
          mod,t,v = lang:parse_module_call(tok,t,v)
-         if mod ~= '...' then
+         if mod and mod ~= '...' then
             add_module(Tags.new{summary='(no description)'},mod,true)
             first_comment = false
             module_found = true

--- a/ldoc/parse.lua
+++ b/ldoc/parse.lua
@@ -231,8 +231,13 @@ local function parse_file(fname, lang, package, args)
       end
    end
    if lang.parse_module_call and t ~= 'comment' then
-      while t and not (t == 'iden' and v == 'module') do
-         t,v = tnext(tok)
+      local prev_token
+      while t do
+         if prev_token ~= '.' and prev_token ~= ':' and t == 'iden' and v == 'module' then
+            break
+         end
+         prev_token = t
+         t, v = tnext(tok)
       end
       if not t then
          if not args.ignore then


### PR DESCRIPTION
Now ldoc doesn't fail on luarocks sources with mysterious errors (caused by `module` word inside a long string).