### PR TITLE
Use dir.makepath when creating output directory

### DIFF
--- a/ldoc/tools.lua
+++ b/ldoc/tools.lua
@@ -14,7 +14,6 @@ local M = tools
 local append = table.insert
 local lexer = require 'ldoc.lexer'
 local quit = utils.quit
-local lfs = require 'lfs'
 
 -- at rendering time, can access the ldoc table from any module item,
 -- or the item itself if it's a module
@@ -225,7 +224,9 @@ end
 
 function M.check_directory(d)
    if not path.isdir(d) then
-      lfs.mkdir(d)
+      if not dir.makepath(d) then
+         quit("Could not create "..d.." directory")
+      end
    end
 end
 


### PR DESCRIPTION
Don't exit with error if an intermediate directory doesn't exist.
The error was not very good either because mkdir failure was not handled (Could not copy /tmp/ldoc_home_mpeterv/ldoc.css to docs/ldoc/ldoc.css).
So, handle directory creation failure.