### PR TITLE
Allow passing configuration values

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -122,7 +122,9 @@ local file_types = {
 ------- ldoc external API ------------
 
 -- the ldoc table represents the API available in `config.ld`.
-local ldoc = { charset = 'UTF-8', version = version }
+local ldoc = { charset = 'UTF-8', version = version}
+
+local config_values = {}
 
 local known_types, kind_names = {}
 
@@ -229,6 +231,10 @@ function ldoc.custom_see_handler(pat, handler)
    doc.add_custom_see_handler(pat, handler)
 end
 
+function ldoc.add_config_value(name, value)
+  config_values[name] = value
+end
+
 local ldoc_contents = {
    'alias','add_language_extension','custom_tags','new_type','add_section', 'tparam_alias',
    'file','project','title','package','format','output','dir','ext', 'topics',
@@ -241,7 +247,8 @@ local ldoc_contents = {
    'dont_escape_underscore','global_lookup','prettify_files','convert_opt', 'user_keywords',
    'postprocess_html',
    'custom_css','version',
-   'no_args_infer'
+   'no_args_infer',
+   'add_config_value'
 }
 ldoc_contents = tablex.makeset(ldoc_contents)
 
@@ -810,6 +817,7 @@ ldoc.modules = module_list
 ldoc.title = ldoc.title or args.title
 ldoc.project = ldoc.project or args.project
 ldoc.package = args.package:match '%a+' and args.package or nil
+ldoc.config = config_values
 
 local source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
 if args.testing then


### PR DESCRIPTION
Add a function to the ldoc API (available in config.ld) to pass some values to the templates.

Typical use case is to use different configuration files between local development and production deployment, using different root address. Hence, you can have a `local_config.ld` with:

    add_config_value('html_root', 'http://localhost:8000')

and the default `config.ld` with:

    add_config_value('html_root', 'https://doc.mydomain.com')

Then in templates, you can use `$(ldoc.config.html_root)` to reffer to the actual value.

Work to do if PR accepted:

- [ ] Update version number
- [ ] Update documentation

Kind.