### PR TITLE
Support for pretty="none"

### DIFF
--- a/ldoc.lua
+++ b/ldoc.lua
@@ -171,7 +171,6 @@ doc.ldoc = ldoc
 
 -- if the corresponding argument was the default, then any ldoc field overrides
 local function override (field,defval)
-   defval = defval or false
    if args[field] == defval and ldoc[field] ~= nil then args[field] = ldoc[field] end
 end
 

--- a/ldoc/markup.lua
+++ b/ldoc/markup.lua
@@ -157,7 +157,7 @@ local function process_multiline_markdown(ldoc, txt, F, filename, deflang)
          line = getline()
       end
       local fence = line:match '^```(.*)'
-      if fence then
+      if prettify.prettifier ~= 'none' and fence then
          local plain = fence==''
          line = getline()
          local code = {}
@@ -174,7 +174,7 @@ local function process_multiline_markdown(ldoc, txt, F, filename, deflang)
          if not line then break end
       end
       indent, line = indent_line(line)
-      if indent >= 4 then -- indented code block
+      if prettify.prettifier ~= 'none' and indent >= 4 then -- indented code block
          local code = {}
          local plain
          while indent >= 4 or blank(line) do

--- a/ldoc/prettify.lua
+++ b/ldoc/prettify.lua
@@ -88,14 +88,16 @@ function prettify.lua (lang, fname, code, initial_lineno, pre, linenos)
    return res:join ()
 end
 
+prettify.prettifier = nil
+
 local lxsh
 
 local lxsh_highlighers = {bib=true,c=true,lua=true,sh=true}
 
 function prettify.code (lang,fname,code,initial_lineno,pre)
-   if not lxsh then
+   if prettify.prettifier == 'lua' then
       return prettify.lua (lang,fname, code, initial_lineno, pre)
-   else
+   elseif prettify.prettifier == 'lxsh' then
       if not lxsh_highlighers[lang] then
          lang = 'lua'
       end
@@ -111,12 +113,14 @@ function prettify.code (lang,fname,code,initial_lineno,pre)
 end
 
 function prettify.set_prettifier (pretty)
+   prettify.prettifier = pretty
    local ok
    if pretty == 'lxsh' then
       ok,lxsh = pcall(require,'lxsh')
       if not ok then
          print('pretty: '..pretty..' not found, using built-in Lua')
          lxsh = nil
+         prettify.prettifier = 'lua'
       end
    end
 end


### PR DESCRIPTION
This adds support for setting `pretty="none"` to work around #162. Doing so disables the prettifier so that it doesn't mess up the parsing of other Markdown constructs.

The `defval = defval or false` part was deleted because it was preventing the `pretty` value from being read from `config.ld`. Actually, this was a bug even before adding the `none` value: e.g. you couldn't set `pretty="lxsh"` before this patch. However, it may be worth double checking if this breaks anything else, since I'm not sufficiently aware of the rest of the code base to know what else this may have interacted with.