### PR TITLE
Add support for Pandoc Markdown

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -754,8 +754,9 @@ Niklas Frykholm. For convenience, LDoc comes with a copy of markdown.lua.
 more features than the pure Lua version, such as PHP-Extra style tables.
   - [lunamark](http://jgm.github.com/lunamark/), another pure Lua processor,  faster than
 markdown, and with extra features (`luarocks install lunamark`).
+  - [pandoc](https://pandoc.org/), a Markdown processor with an extensive feature set (see [here](https://pandoc.org/installing.html) for installation and make sure `pandoc` is on `PATH`).
 
-You can request the processor you like with `format = 'markdown|discount|lunamark|plain|backticks'`, and
+You can request the processor you like with `format = 'markdown|discount|lunamark|pandoc|plain|backticks'`, and
 LDoc will attempt to use it.  If it can't find it, it will look for one of the other
 markdown processors; the original `markdown.lua` ships with LDoc, although it's slow
 for larger documents.
@@ -1184,7 +1185,7 @@ of files and directories.
   - `title` page title, default 'Reference'
   - `package ` explicit base package name; also used for resolving references in documents
   - `all` show local functions, etc as well in the docs
-  - `format` markup processor, can be 'plain' (default), 'markdown' or 'discount'
+  - `format` markup processor, can be 'plain' (default), 'markdown', 'discount', 'lunamark' or 'pandoc'
   - `output` output name (default 'index')
   - `dir` directory for output files (default 'doc')
   - `colon` use colon style, instead of @ tag style

--- a/ldoc/html/_code_css.lua
+++ b/ldoc/html/_code_css.lua
@@ -16,4 +16,13 @@ pre .user-keyword { color: #800080; }
 pre .prompt { color: #558817; }
 pre .url { color: #272fc2; text-decoration: underline; }
 
+/* same, for Pandoc code highlighting */
+code span.co { color: #558817; }
+code span.cn { color: #a8660d; }
+code span.kw, code span.cf { color: #aa5050; font-weight: bold; }
+code span.st { color: #8080ff; }
+code span.dv { color: #f8660d; }
+code span.pp { color: #a33243; }
+code span.va { color: #800080; }
+
 ]]

--- a/ldoc/markup.lua
+++ b/ldoc/markup.lua
@@ -275,6 +275,20 @@ local formatters =
                                                     { smart = true })
          return function(text) return parse(text) end
       end
+   end,
+   pandoc = function(format)
+     return function(text)
+       local out_filename = os.tmpname()
+       local in_file = io.popen("pandoc -f markdown -t html -o " .. out_filename .. " -", "w")
+       in_file:write(text)
+       in_file:close()
+
+       local out_file = io.open(out_filename, "rb")
+       local out_content = out_file:read("*all")
+       out_file:close()
+       os.remove(out_filename)
+       return out_content
+     end
    end
 }
 


### PR DESCRIPTION
This is another part of the solution to #162, along with #326. This PR adds support for [Pandoc](https://pandoc.org/), which is a very robust and featureful Markdown processor written in Haskell. Since there's not really any way to directly integrate the library we just assume it's on `PATH` and call it as an external program.

I've tried to minimize the number of temporary files created, but apparently Lua has no `popen2` equivalent so I think this is the best we can do (without additional dependencies or extensions).

I've confirmed that this works to at least a basic level with Pandoc's built-in syntax highlighting if you use it in combination with #326 and set `pretty="none"`.