### PR TITLE
Fix references to class types.

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -1066,9 +1066,9 @@ end
 local function reference (s, mod_ref, item_ref)
    local name = item_ref and item_ref.name or ''
    -- this is deeply hacky; classes have 'Class ' prepended.
---~    if item_ref and doc.class_tag(item_ref.type) then
---~       name = 'Class_'..name
---~    end
+       if item_ref and doc.class_tag(item_ref.type) then
+          name = 'Class_'..name
+       end
    return {mod = mod_ref, name = name, label=s}
 end
 


### PR DESCRIPTION
For classes the generated HTML anchors need to be prefixed 'Class_'.

Fixes: https://github.com/lunarmodules/ldoc/issues/413