### PR TITLE
#405 Fixed where some functions were showing as "signals"

### DIFF
--- a/ldoc/doc.lua
+++ b/ldoc/doc.lua
@@ -37,6 +37,7 @@ local known_tags = {
 
 }
 known_tags._alias = {}
+known_tags._alias['signal'] = 'function'
 known_tags._project_level = {
    module = true,
    script = true,


### PR DESCRIPTION
Added signal as an alias to function in known_tags._alias in ldoc/doc.lua
Fixes the issue in : luainkernel/lunatik#405