### PR TITLE
fix(html): paragraph markers for multiple entries

### DIFF
--- a/ldoc/html/ldoc_ltp.lua
+++ b/ldoc/html/ldoc_ltp.lua
@@ -183,7 +183,9 @@ return [==[
 #  end
     </dt>
     <dd>
+    <p>
     $(M(ldoc.descript(item),item))
+    </p>
 
 #   if ldoc.custom_tags then
 #    for custom in iter(ldoc.custom_tags) do


### PR DESCRIPTION
If multiple entries are inserted, they will be separated by "&lt;/p>&lt;p>" which results in broken tags if there are no leading and trailing tags.